### PR TITLE
GraphQL Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ cmake-build-*/
 # IntelliJ
 out/
 
+# Netbeans
+nb*
+
 # mpeltonen/sbt-idea plugin
 .idea_modules/
 

--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -45,19 +45,15 @@
             <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-graphql-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-rest-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>io.quarkus</groupId>-->
-<!--            <artifactId>quarkus-smallrye-graphql-client</artifactId>-->
-<!--            <exclusions>-->
-<!--                <exclusion>-->
-<!--                    <groupId>io.quarkus</groupId>-->
-<!--                    <artifactId>quarkus-rest-client</artifactId>-->
-<!--                </exclusion>-->
-<!--            </exclusions>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http</artifactId>

--- a/api-gateway/src/main/java/me/escoffier/gateway/Api.java
+++ b/api-gateway/src/main/java/me/escoffier/gateway/Api.java
@@ -40,4 +40,13 @@ public class Api {
                 ).log();
     }
 
+    // TEMP to test
+    @GET @Path("/hero")
+    public Uni<Hero> getHero(){
+        Uni<Hero> hero = heroes.getRandomHero();
+        return hero;
+        
+    }
+    
+    
 }

--- a/api-gateway/src/main/java/me/escoffier/gateway/Hero.java
+++ b/api-gateway/src/main/java/me/escoffier/gateway/Hero.java
@@ -1,10 +1,14 @@
 package me.escoffier.gateway;
 
+import javax.json.bind.annotation.JsonbProperty;
 import me.escoffier.fight.FightServiceOuterClass;
+// import org.eclipse.microprofile.graphql.Name;
 
 public class Hero {
 
     public String name;
+    // @Name("image") // TODO: This should work, log a bug,for now using JsonB alternative 
+    @JsonbProperty("image")
     public String picture;
     public int level;
 

--- a/api-gateway/src/main/java/me/escoffier/gateway/HeroService.java
+++ b/api-gateway/src/main/java/me/escoffier/gateway/HeroService.java
@@ -1,73 +1,42 @@
 package me.escoffier.gateway;
 
+import io.smallrye.graphql.client.NamedClient;
+import io.smallrye.graphql.client.core.Document;
+import static io.smallrye.graphql.client.core.Field.field;
+import static io.smallrye.graphql.client.core.Document.document;
+import static io.smallrye.graphql.client.core.Operation.operation;
+import io.smallrye.graphql.client.core.OperationType;
+import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 import io.smallrye.mutiny.Uni;
-import io.vertx.core.json.JsonObject;
-import io.vertx.mutiny.core.Vertx;
-import io.vertx.mutiny.core.buffer.Buffer;
-import io.vertx.mutiny.ext.web.client.WebClient;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.eclipse.microprofile.faulttolerance.Retry;
-
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import java.time.temporal.ChronoUnit;
 
+
+/**
+ * GraphQL Client
+ * @see https://quarkus.io/version/main/guides/smallrye-graphql-client
+ */
 @ApplicationScoped
 public class HeroService {
 
-    @ConfigProperty(name = "hero-service")
-    String url;
-
     @Inject
-    Vertx vertx;
-    private WebClient client;
-    private JsonObject query;
-
-    @PostConstruct
-    public void init() {
-        client = WebClient.create(vertx);
-        query = new JsonObject();
-        query.put("query", "{randomHero {"
-                    + "name, "
-                    + "picture:image, "
-                    + "level "
-                    + "}"
-                + "}");
-    }
-
-    @Retry(maxRetries = 5, delay = 100, delayUnit = ChronoUnit.MILLIS)
+    @NamedClient("hero-service")
+    DynamicGraphQLClient qlClient;
+    
     public Uni<Hero> getRandomHero() {
-        return client.postAbs(url + "/graphql")
-                .sendJsonObject(query)
-                .onItem().transform(resp -> resp.bodyAsJsonObject().getJsonObject("data").getJsonObject("randomHero"))
-                .onItem().transform(json -> json.mapTo(Hero.class))
-                .log("hero-service");
+        
+        Document randomHero = document(
+                operation(OperationType.QUERY,
+                        field("randomHero",
+                                field("name"),
+                                field("level"),
+                                field("image")
+                        )));
+
+        
+        return qlClient.executeAsync(randomHero)
+                .onItem().transform(response -> response.getObject(Hero.class, "randomHero"));
     }
 
-    //    private DynamicGraphQLClient qlClient;
-    //
-    //    @PostConstruct
-    //    public void init() {
-    //        qlClient = DynamicGraphQLClientBuilder.newBuilder().url(url + "/graphql").build();
-    //    }
-    //
-    //    public Uni<Hero> getRandomHero() {
-    //        Field q = field("randomHero");
-    //        q.setFields(List.of(field("name"), field("level"), field("image")));
-    //        Operation query = Operation.operation(q);
-    //
-    //        return qlClient.executeAsync(document(query))
-    //                .onItem().transform(response -> createHero(response.getData()));
-    //    }
-    //
-//        private Hero createHero(JsonObject data) {
-//            JsonObject res = data.getJsonObject("randomHero");
-//            Hero hero = new Hero();
-//            hero.name = res.getString("name");
-//            hero.level = res.getInteger("level");
-//            hero.picture = res.getString("image");
-//            return hero;
-//        }
 
 }

--- a/api-gateway/src/main/resources/application.properties
+++ b/api-gateway/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 quarkus.http.port=9999
 
 villain-service/mp-rest/url=http://localhost:9000
-hero-service=http://localhost:9001
+hero-service/mp-graphql/url=http://localhost:9001/graphql
 
 quarkus.grpc.clients.fight-service.host=localhost
 quarkus.grpc.clients.fight-service.port=9004

--- a/heroes-service/pom.xml
+++ b/heroes-service/pom.xml
@@ -38,23 +38,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-graphql</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-graphql-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Ok, so I think we need to remove the dependency to rest client in the quarkus extension (@jmartisk) or make it optional. And let the user pull in the appropriate chosen client.

This code keep the <exclude> in the pom and it still works because the reactive client is available.

There is also a bug (I think) where the `@Name` annotation is not working (but the JsonB one is) we need to look at that.

I only tested the API with a new temp rest endpoint, and not the full fight. 

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>